### PR TITLE
Fix dependency on go4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.12
 
 require (
 	github.com/frankban/quicktest v0.0.0-20171023143956-9332c2fb618e
-	github.com/go4org/go4 v0.0.0-20190313082347-94abd6928b1d
 	github.com/google/go-cmp v0.0.0-20171005193144-7ffe1921f7d7 // indirect
 	github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c // indirect
 	github.com/juju/errors v0.0.0-20190207033735-e65537c515d7 // indirect
@@ -14,6 +13,7 @@ require (
 	github.com/juju/utils v0.0.0-20180808125547-9dfc6dbfb02b // indirect
 	github.com/juju/version v0.0.0-20180108022336-b64dbd566305 // indirect
 	github.com/kr/pretty v0.1.0 // indirect
+	go4.org v0.0.0-20190313082347-94abd6928b1d
 	golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5 // indirect
 	golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/frankban/quicktest v0.0.0-20171023143956-9332c2fb618e h1:LN7YRsIDybsmepzdm9hb+Lk++BVqwWZC6jOGSDAdkOs=
 github.com/frankban/quicktest v0.0.0-20171023143956-9332c2fb618e/go.mod h1:1Bb+ZdFimNFekaSbjJw9uAMDBC4SvpBzuk2wc0U1Dqk=
-github.com/go4org/go4 v0.0.0-20190313082347-94abd6928b1d h1:8abl05vPDym3FmkxM59ndh7fTi6XMiSApDE/N0Lzb0o=
-github.com/go4org/go4 v0.0.0-20190313082347-94abd6928b1d/go.mod h1:BLAKVUWoYZ2kTodPmXRcZB5wK1cHTxSfm3pGzLp+dqk=
 github.com/google/go-cmp v0.0.0-20171005193144-7ffe1921f7d7 h1:sGSS0KJDeDcMaftdKeHqDQBXgnlXD2LF61i6nldatJk=
 github.com/google/go-cmp v0.0.0-20171005193144-7ffe1921f7d7/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c h1:3UvYABOQRhJAApj9MdCN+Ydv841ETSoy6xLzdmmr/9A=
@@ -23,6 +21,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+go4.org v0.0.0-20190313082347-94abd6928b1d h1:JkRdGP3zvTtTbabWSAC6n67ka30y7gOzWAah4XYJSfw=
+go4.org v0.0.0-20190313082347-94abd6928b1d/go.mod h1:MkTOUMDaeVYJUOUsaDXIhWPZYa1yOyC1qaOBpL57BhE=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5 h1:58fnuSXlxZmFdJyvtTFVmVhcMLU6v5fEb/ok4wyqtNU=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=

--- a/serialize.go
+++ b/serialize.go
@@ -15,7 +15,7 @@ import (
 
 	"gopkg.in/retry.v1"
 
-	filelock "github.com/go4org/go4/lock"
+	filelock "go4.org/lock"
 	"gopkg.in/errgo.v1"
 )
 


### PR DESCRIPTION
The `go mod` dependency resolution fails with the below error on newer
versions of Go lang

```
go get: gitthub.com/go4org/go4@v0.0.0-20190313082347-94abd6928b1d updating to
        github.com/go4org/go4@v0.0.0-20200312051459-7028f7b4a332: parsing go.mod:
        module declares its path as: go4.org
                but was required as: github.com/go4org/go4
```

This is caused by using the wrong format for the reference to go4.org packages.